### PR TITLE
Manually keep Worker constructor

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,8 @@
 
 # Gson specific classes
 -keep class com.google.gson.stream.** { *; }
+
+# WorkManager workaround for https://issuetracker.google.com/issues/116296569
+-keepclassmembers class * extends androidx.work.Worker {
+	public <init>(android.content.Context,androidx.work.WorkerParameters);
+}


### PR DESCRIPTION
Per [this issue](https://issuetracker.google.com/issues/116296569), WorkManager 1.0.0-alpha09 does not keep the `Worker(Context, WorkerParameters)` constructor, causing issues at runtime where no Worker can be instantiated.

As a workaround, add our own keep rule for that constructor until such a time when WorkManager 1.0.0-alpha10 is released with the fix.