### PR TITLE
Update to Muzei API 3.0.0-beta02

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,7 @@ dependencies {
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 
-    implementation 'com.google.android.apps.muzei:muzei-api:3.0.0-beta01'
+    implementation 'com.google.android.apps.muzei:muzei-api:3.0.0-beta02'
 
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
 


### PR DESCRIPTION
Update to 3.0.0-beta02 to get the fix for [exported providers](https://github.com/romannurik/muzei/issues/577)