### PR TITLE
Upgrade to Muzei API 3.4, AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,11 +71,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-    // Workaround for WorkManager alpha09: https://developer.android.com/jetpack/docs/release-notes#september_19_2018
-    packagingOptions {
-        exclude 'META-INF/proguard/androidx-annotations.pro'
-    }
 }
 
 staticAnalysis {
@@ -109,11 +104,11 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation 'android.arch.work:work-runtime:1.0.0-alpha09'
+    implementation 'androidx.work:work-runtime:2.4.0'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 
-    implementation 'com.google.android.apps.muzei:muzei-api:3.0.0-beta03'
+    implementation 'com.google.android.apps.muzei:muzei-api:3.4.0'
 
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
     android:name=".App"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
-    tools:ignore="GoogleAppIndexingWarning"
+    android:usesCleartextTraffic="true"
+    tools:ignore="GoogleAppIndexingWarning,UnusedAttribute"
     android:fullBackupContent="@xml/backup_descriptor">
 
     <provider

--- a/app/src/main/java/com/tasomaniac/muzei/comiccovers/ComicVineArtProvider.java
+++ b/app/src/main/java/com/tasomaniac/muzei/comiccovers/ComicVineArtProvider.java
@@ -4,7 +4,7 @@ import com.google.android.apps.muzei.api.provider.MuzeiArtProvider;
 
 public class ComicVineArtProvider extends MuzeiArtProvider {
 
-    @Override protected void onLoadRequested(boolean initial) {
+    @Override public void onLoadRequested(boolean initial) {
         ComicVineWorker.enqueue();
     }
 

--- a/app/src/main/java/com/tasomaniac/muzei/comiccovers/ComicVineWorker.java
+++ b/app/src/main/java/com/tasomaniac/muzei/comiccovers/ComicVineWorker.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
@@ -45,19 +45,19 @@ public class ComicVineWorker extends Worker {
             Comic comic = getNextComic(service);
 
             if (comic == null) {
-                return Result.FAILURE;
+                return Result.failure();
             }
 
             prefs.edit().putString(COMIC_ID, String.valueOf(comic.getId())).apply();
 
-            ProviderContract.Artwork.addArtwork(
+            ProviderContract.getProviderClient(
                     getApplicationContext(),
-                    BuildConfig.COMIC_VINE_AUTHORITY,
-                    toArtwork(comic));
-            return Result.SUCCESS;
+                    BuildConfig.COMIC_VINE_AUTHORITY)
+                    .addArtwork(toArtwork(comic));
+            return Result.success();
         } catch (IOException e) {
             Timber.e(e, "No internet connection");
-            return Result.RETRY;
+            return Result.retry();
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     def versionBuild = 4
 
     ext.versions = [
-            compileSdk : 28,
+            compileSdk : 30,
             minSdk     : 19,
             versionCode: versionMajor * 10000 + versionMinor * 100 + versionBuild,
             versionName: "${versionMajor}.${versionMinor}",
@@ -20,13 +20,13 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.2'
         classpath 'com.novoda:gradle-android-command-plugin:2.0.1'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
-        classpath 'io.fabric.tools:gradle:1.26.1'
+        classpath 'com.novoda:gradle-static-analysis-plugin:1.2'
+        classpath 'io.fabric.tools:gradle:1.31.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 org.gradle.caching=true
 org.gradle.parallel=true
-android.enableR8=false
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update to Muzei API 3.4, which fixes an issue with opening the art details via the web uri on Android 10+ devices.

This upgrade required a number of infrastructure upgrades:
- Muzei uses a `compileSdkVersion` of 30, which required an update to Android Gradle Plugin 4.0.1
- Due to the upgrade of AGP, Gradle was updated to 6.5, Fabric to 1.31.0, gradle-static-analysis-plugin to 1.2, and the deprecated `android.enableR8` has been removed.
- Muzei requires AndroidX, which required upgrading to an AndroidX version of WorkManager (the latest, 2.4.0)
- The upgrade in `compileSdkVersion` meant that we needed to add `android:usesCleartextTraffic="true"` to the manifest to support `http` URIs returned by the API (it is unclear from the API documentation if they fully support `https`)
- Changes to `ComicVineArtProvider` and `ComicVineWorker`'s use of Muzei APIs to avoid deprecated/changed APIs